### PR TITLE
build: Reset github token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
@@ -14,7 +16,7 @@ jobs:
         id: release
         with:
           release-type: node
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
 
   publish-release:
     permissions:
@@ -22,6 +24,8 @@ jobs:
       id-token: write
     needs: release-please
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - uses: linz/action-typescript@v3
@@ -30,4 +34,4 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN_LINZJS}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.LI_GITHUB_ACTION_TOKEN}}


### PR DESCRIPTION
#### Motivation 
`release-please` has been blocked by security team, and to enable it we will need to setup PAT for them via `linz-li-bot` account.  

#### Modification

- We have setup the `linz-li-bot` secrets in https://github.com/linz/github-tf/blob/02ff18887e650129951f6e391a18f377fb87be80/src/repo/repo.linz.js.ts#L8
- Update the code changes to point to the new secrets